### PR TITLE
Export user menu data types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,12 @@ export {
     useNotificationCenter,
 } from './core/NotificationCenter';
 
-export { default as UserMenuContainer, useCustomUserMenuSection } from './core/UserMenuContainer';
+export {
+    default as UserMenuContainer,
+    useCustomUserMenuSection,
+    UserMenuSection,
+    UserMenuSectionItem,
+} from './core/UserMenuContainer';
 
 export { default as useDebouncedAbortable } from './hooks/useDebouncedAbortable';
 export { default as useDebounce } from './hooks/useDebounce';


### PR DESCRIPTION
Added `UserMenuSection` and `UserMenuSectionItem` to the list of exports from the `UserMenuContainer` in order to enable cleaner imports for users of the `useCustomUserMenuSection` hook.