### PR TITLE
Adds function to set user role status on PeopleContainer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,3 +139,9 @@ export * from './intl/DateTime';
 export * from './intl/Number';
 
 export * from './http/hooks/dataProxy/useHandover';
+
+export {
+    default as EventEmitter,
+    useEventEmitterValue,
+    useEventEmitter,
+} from './utils/EventEmitter';

--- a/src/utils/EventEmitter/index.ts
+++ b/src/utils/EventEmitter/index.ts
@@ -70,3 +70,17 @@ export const useEventEmitterValue = <
 
     return [value, setValue];
 };
+
+export const useEventEmitter = <
+    TEvents extends Events,
+    TKey extends keyof TEvents,
+    TData = EventHandlerParameter<TEvents, TKey>
+>(
+    emitter: EventEmitter<TEvents>,
+    event: TKey,
+    handler: (arg: TData) => void
+) => {
+    useEffect(() => {
+        return emitter.on(event, handler);
+    }, [emitter, event, handler]);
+};


### PR DESCRIPTION
When implementing the [claimable roles feature](https://dev.azure.com/statoil-proview/Fusion/_workitems/edit/7870), we needed a way to change the status of a user role. Instead of doing this directly using the `PeopleClient`, we want to expose this functionality on the `PeopleContainer` instead so that we can handle updates in the cache and notify hooks of possible changes on a person.

**Changes**
- `PeopleContainer` is now an event emmiter that emits an event whenver a person is updated (currently only when a role changes status)
- Added a new hook `useEventEmitter` that accepts a custom handler function
- Added a new function `setRoleStatusForUser` on the `PeopleContainer` that should be used when updating user roles (instead of using the `PeopleClient` directly).