### PR TITLE
Update cached role in PeopleContainer if the role exists

### DIFF
--- a/src/core/PeopleContainer.ts
+++ b/src/core/PeopleContainer.ts
@@ -69,7 +69,7 @@ export default class PeopleContainer extends EventEmitter<PersonContainerEvents>
         const roles = this.persons[personId].roles;
         if (roles) {
             const roleIndex = roles.findIndex(role => role.name === roleName);
-            if (roleIndex) {
+            if (roleIndex !== -1) {
                 roles[roleIndex] = response.data;
                 this.emit('updated', { ...this.persons[personId] });
             }


### PR DESCRIPTION
If the cached role was at index 0, it would not be updated because we checked if `roleIndex` was truthy instead of checking if it was different from -1 (which is what `findIndex` returns if it can not determine the index).

In cases where the role was at index 0, it would not be updated in the local cache because 0 is not truthy in Javascript...