### PR TITLE
Fix consecutive sign in with invalid reply url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/fusion",
-  "version": "0.4.58",
+  "version": "0.4.59",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/fusion",
-  "version": "0.4.56",
+  "version": "0.4.57",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion",
-    "version": "0.4.56",
+    "version": "0.4.57",
     "description": "Everything a Fusion app needs to communicate with the core",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/fusion",
-    "version": "0.4.58",
+    "version": "0.4.59",
     "description": "Everything a Fusion app needs to communicate with the core",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/auth/AuthContainer.ts
+++ b/src/auth/AuthContainer.ts
@@ -238,7 +238,7 @@ export default class AuthContainer implements IAuthContainer {
             ...customParams,
             client_id: app.clientId,
             response_type: 'id_token',
-            redirect_uri: getTopLevelWindow(window).location.href,
+            redirect_uri: getTopLevelWindow(window).location.href.split("#")[0],
             nonce: nonce.getKey(),
             login_hint: cachedUser ? cachedUser.upn : null,
         };


### PR DESCRIPTION
## The problem
1. User with expired token in token cache opens an app in fusion that requires a token from another app
2. The portal redirects to interactive signin for fusion
3. AD redirects back to fusion with id token in the hash/url fragment
4. The app requests token for it's own azure ad app
5. The portal redirects to interactive signin for the other app, but this time the empty fragment (#) is in the reply url since the AuthContainer uses window.location.href as reply url
6. AD looks for https://fusion.equinor.com/apps/something# in reply urls, but # in reply urls is not permitted
7. Login fails

## The solution
Remove the hash/url fragment from the reply url