### PR TITLE
Implementations for ContextTypes In AppManifest

### DIFF
--- a/src/http/apiClients/models/context/Context.ts
+++ b/src/http/apiClients/models/context/Context.ts
@@ -1,4 +1,4 @@
-import { ContextType } from "./ContextTypes";
+import { ContextType } from './ContextTypes';
 
 type ParentContext = {
     id: string;

--- a/src/http/apiClients/models/context/ContextManifest.ts
+++ b/src/http/apiClients/models/context/ContextManifest.ts
@@ -1,0 +1,9 @@
+import { ContextType } from './ContextTypes';
+
+export class ContextManifest {
+    readonly types: ContextType[];
+
+    constructor(types: ContextType[]) {
+        this.types = types;
+    }
+}

--- a/src/http/apiClients/models/context/index.ts
+++ b/src/http/apiClients/models/context/index.ts
@@ -1,2 +1,3 @@
-export { Context } from "./Context";
-export { ContextType, ContextTypes } from "./ContextTypes";
+export { Context } from './Context';
+export { ContextType, ContextTypes } from './ContextTypes';
+export { ContextManifest } from './ContextManifest';

--- a/src/http/apiClients/models/fusion/apps/AppManifest.ts
+++ b/src/http/apiClients/models/fusion/apps/AppManifest.ts
@@ -1,4 +1,4 @@
-import { ContextTypes } from '../../context';
+import { ContextManifest } from '../../context';
 
 export type AppAuth = {
     clientId: string;
@@ -12,9 +12,9 @@ type AppManifest = {
     version: string;
     description: string;
     tags: string[];
-    contextTypes?: ContextTypes[];
+    context?: ContextManifest;
     auth?: AppAuth;
     icon?: string;
-}
+};
 
 export default AppManifest;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,12 @@ export {
 } from './http/apiClients/models/common/FusionApiHttpErrorResponse';
 
 export { Context, ContextType, ContextTypes } from './http/apiClients/models/context';
-export { useContextManager, useCurrentContext, useContextQuery } from './core/ContextManager';
+export {
+    useContextManager,
+    useCurrentContext,
+    useContextQuery,
+    useCurrentContextTypes,
+} from './core/ContextManager';
 
 export { withAbortController, useAbortControllerManager } from './utils/AbortControllerManager';
 


### PR DESCRIPTION
Added property in appmanifest for defining contexttype used by app.
ContextManager now has a new hook that exposes the current useable contexttype for current app.
Removed contexttypes as a parameter from ContextManager hooks.
Contexttypes instead comes from the new useCurrentContextType Hook