### PR TITLE
Add http verb methods to api clients

### DIFF
--- a/src/core/FusionContext.ts
+++ b/src/core/FusionContext.ts
@@ -142,7 +142,7 @@ export const createFusionContext = (
 
     const resourceCache = new ResourceCache();
     const httpClient = new HttpClient(authContainer, resourceCache, abortControllerManager, telemetryLogger);
-    const apiClients = createApiClients(httpClient, resourceCollections);
+    const apiClients = createApiClients(httpClient, resourceCollections, serviceResolver);
 
     const history = createBrowserHistory();
 

--- a/src/http/apiClients/BaseApiClient.ts
+++ b/src/http/apiClients/BaseApiClient.ts
@@ -1,12 +1,43 @@
 import { IHttpClient } from "../HttpClient";
 import ResourceCollections from "../resourceCollections";
+import { combineUrls } from '../../utils/url';
+import { FusionApiHttpErrorResponse } from './models/common/FusionApiHttpErrorResponse';
+import { ResponseParser } from '../HttpClient/IHttpClient';
+import ServiceResolver from '../resourceCollections/ServiceResolver';
 
 export default abstract class BaseApiClient {
     protected httpClient: IHttpClient;
     protected resourceCollections: ResourceCollections;
 
-    constructor(httpClient: IHttpClient, resourceCollection: ResourceCollections) {
+    constructor(httpClient: IHttpClient, resourceCollection: ResourceCollections, protected serviceResolver: ServiceResolver) {
         this.httpClient = httpClient;
         this.resourceCollections = resourceCollection;
+    }
+
+    protected abstract getBaseUrl(): string;
+
+    public async getAsync<TResponse>(path: string, init?: RequestInit, responseParser?: ResponseParser<TResponse>) {
+        const url = combineUrls(this.getBaseUrl(), path);
+        return await this.httpClient.getAsync<TResponse, FusionApiHttpErrorResponse>(url, init, responseParser);
+    }
+
+    public async postAsync<TBody, TResponse>(path: string, body: TBody, init?: RequestInit, responseParser?: ResponseParser<TResponse>) {
+        const url = combineUrls(this.getBaseUrl(), path);
+        return await this.httpClient.postAsync<TBody, TResponse, FusionApiHttpErrorResponse>(url, body, init, responseParser);
+    }
+
+    public async putAsync<TBody, TResponse>(path: string, body: TBody, init?: RequestInit, responseParser?: ResponseParser<TResponse>) {
+        const url = combineUrls(this.getBaseUrl(), path);
+        return await this.httpClient.putAsync<TBody, TResponse, FusionApiHttpErrorResponse>(url, body, init, responseParser);
+    }
+
+    public async patchAsync<TBody, TResponse>(path: string, body: TBody, init?: RequestInit, responseParser?: ResponseParser<TResponse>) {
+        const url = combineUrls(this.getBaseUrl(), path);
+        return await this.httpClient.patchAsync<TBody, TResponse, FusionApiHttpErrorResponse>(url, body, init, responseParser);
+    }
+
+    public async deleteAsync<TResponse>(path: string, init?: RequestInit, responseParser?: ResponseParser<TResponse>) {
+        const url = combineUrls(this.getBaseUrl(), path);
+        return await this.httpClient.deleteAsync<TResponse, FusionApiHttpErrorResponse>(url, init, responseParser);
     }
 }

--- a/src/http/apiClients/ContextClient.ts
+++ b/src/http/apiClients/ContextClient.ts
@@ -3,6 +3,10 @@ import { FusionApiHttpErrorResponse } from "./models/common/FusionApiHttpErrorRe
 import { Context, ContextTypes } from "./models/context";
 
 export default class ContextClient extends BaseApiClient {
+    protected getBaseUrl() {
+        return this.serviceResolver.getContextBaseUrl();
+    }
+    
     async getContextsAsync() {
         const url = this.resourceCollections.context.contexts();
         return await this.httpClient.getAsync<Context[], FusionApiHttpErrorResponse>(url);

--- a/src/http/apiClients/DataProxyClient.ts
+++ b/src/http/apiClients/DataProxyClient.ts
@@ -37,6 +37,10 @@ export {
 };
 
 export default class DataProxyClient extends BaseApiClient {
+    protected getBaseUrl() {
+        return this.serviceResolver.getDataProxyBaseUrl();
+    }
+    
     async getHandoverAsync(siteCode: string, projectIdentifier: string) {
         const url = this.resourceCollections.dataProxy.handover(siteCode, projectIdentifier);
         return await this.httpClient.getAsync<HandoverItem[], FusionApiHttpErrorResponse>(url);

--- a/src/http/apiClients/FusionClient.ts
+++ b/src/http/apiClients/FusionClient.ts
@@ -4,6 +4,10 @@ import AppManifest from './models/fusion/apps/AppManifest';
 import getScript from '../../utils/getScript';
 
 export default class FusionClient extends BaseApiClient {
+    protected getBaseUrl() {
+        return this.serviceResolver.getFusionBaseUrl();
+    }
+    
     async getAppsAsync() {
         const url = this.resourceCollections.fusion.apps();
         return await this.httpClient.getAsync<AppManifest[], FusionApiHttpErrorResponse>(url);

--- a/src/http/apiClients/OrgClient.ts
+++ b/src/http/apiClients/OrgClient.ts
@@ -4,6 +4,10 @@ import Position from './models/org/Position';
 import OrgProject, { FusionProject, BasePosition, CreateOrgProject } from './models/org/OrgProject';
 
 export default class OrgClient extends BaseApiClient {
+    protected getBaseUrl() {
+        return this.serviceResolver.getOrgBaseUrl();
+    }
+    
     async getProjectsAsync() {
         const url = this.resourceCollections.org.projects();
         return await this.httpClient.getAsync<OrgProject[], FusionApiHttpErrorResponse>(url);

--- a/src/http/apiClients/PeopleClient.ts
+++ b/src/http/apiClients/PeopleClient.ts
@@ -15,6 +15,7 @@ import { FusionApiHttpErrorResponse } from './models/common/FusionApiHttpErrorRe
 import { PersonODataExpand } from '../resourceCollections/PeopleResourceCollection';
 import GroupRoleMapping from './models/people/GroupRoleMapping';
 import RoleStatus from './models/people/RoleStatus';
+import ServiceResolver from '../resourceCollections/ServiceResolver';
 
 export {
     PersonDetails,
@@ -29,8 +30,8 @@ export {
 };
 
 export default class PeopleClient extends BaseApiClient {
-    constructor(httpClient: IHttpClient, resourceCollection: ResourceCollections) {
-        super(httpClient, resourceCollection);
+    constructor(httpClient: IHttpClient, resourceCollection: ResourceCollections, serviceResolver: ServiceResolver) {
+        super(httpClient, resourceCollection, serviceResolver);
 
         httpClient.getAsync<void, unknown>(
             resourceCollection.people.apiSignin(),
@@ -39,6 +40,10 @@ export default class PeopleClient extends BaseApiClient {
         );
     }
 
+    protected getBaseUrl() {
+        return this.serviceResolver.getPeopleBaseUrl();
+    }
+    
     async getPersonDetailsAsync(id: string, oDataExpand?: PersonODataExpand[]) {
         const url = this.resourceCollections.people.getPersonDetails(id, oDataExpand);
         return await this.httpClient.getAsync<PersonDetails, FusionApiHttpErrorResponse>(url, {

--- a/src/http/apiClients/PowerBIClient.ts
+++ b/src/http/apiClients/PowerBIClient.ts
@@ -19,6 +19,10 @@ export default class PowerBIClient extends BaseApiClient {
     private dashboards: IDashboardItem = {};
     private powerBiToken: string = '';
 
+    protected getBaseUrl() {
+        return this.serviceResolver.getReportsBaseUrl();
+    }
+    
     private async getPowerBITokenAsync(): Promise<string> {
         if (this.powerBiToken && AuthToken.parse(this.powerBiToken).isValid())
             return this.powerBiToken;

--- a/src/http/apiClients/ReportClient.ts
+++ b/src/http/apiClients/ReportClient.ts
@@ -7,6 +7,10 @@ import ConfigValidation from './models/report/ConfigValidation';
 import BaseApiClient from './BaseApiClient';
 
 export default class ReportClient extends BaseApiClient {
+    protected getBaseUrl() {
+        return this.serviceResolver.getReportsBaseUrl();
+    }
+    
     async getReportsAsync() {
         const url = this.resourceCollections.report.reports();
         return await this.httpClient.getAsync<Report[], FusionApiHttpErrorResponse>(url);

--- a/src/http/apiClients/TasksClient.ts
+++ b/src/http/apiClients/TasksClient.ts
@@ -3,6 +3,10 @@ import { FusionApiHttpErrorResponse } from './models/common/FusionApiHttpErrorRe
 import Task, { TaskSourceSystem, TaskType, TaskTypes } from './models/tasks/Task';
 
 export default class TasksClient extends BaseApiClient {
+    protected getBaseUrl() {
+        return this.serviceResolver.getTasksBaseUrl();
+    }
+    
     async getSourceSystemsAsync() {
         const url = this.resourceCollections.tasks.sourceSystems();
         return this.httpClient.getAsync<TaskSourceSystem[], FusionApiHttpErrorResponse>(url);

--- a/src/http/apiClients/index.ts
+++ b/src/http/apiClients/index.ts
@@ -8,6 +8,7 @@ import PeopleClient from './PeopleClient';
 import OrgClient from './OrgClient';
 import ReportClient from './ReportClient';
 import PowerBIClient from './PowerBIClient';
+import ServiceResolver from '../resourceCollections/ServiceResolver';
 
 export { FusionApiHttpErrorResponse } from './models/common/FusionApiHttpErrorResponse';
 
@@ -24,16 +25,17 @@ type ApiClients = {
 
 export const createApiClients = (
     httpClient: IHttpClient,
-    resources: ResourceCollections
+    resources: ResourceCollections,
+    serviceResolver: ServiceResolver
 ): ApiClients => ({
-    dataProxy: new DataProxyClient(httpClient, resources),
-    fusion: new FusionClient(httpClient, resources),
-    context: new ContextClient(httpClient, resources),
-    tasks: new TasksClient(httpClient, resources),
-    people: new PeopleClient(httpClient, resources),
-    org: new OrgClient(httpClient, resources),
-    report: new ReportClient(httpClient, resources),
-    powerBI: new PowerBIClient(httpClient, resources),
+    dataProxy: new DataProxyClient(httpClient, resources, serviceResolver),
+    fusion: new FusionClient(httpClient, resources, serviceResolver),
+    context: new ContextClient(httpClient, resources, serviceResolver),
+    tasks: new TasksClient(httpClient, resources, serviceResolver),
+    people: new PeopleClient(httpClient, resources, serviceResolver),
+    org: new OrgClient(httpClient, resources, serviceResolver),
+    report: new ReportClient(httpClient, resources, serviceResolver),
+    powerBI: new PowerBIClient(httpClient, resources, serviceResolver),
 });
 
 export default ApiClients;


### PR DESCRIPTION
## Motivation
If you need to make a request that's a bit to specific to implement in the api clients, you have to combine the service resolver and http client to make requests

## Solution
Add get, post, put and patch to the base api client (and all the api clients by inheritance.) Each api client provides their base url, and the base api client uses that to combine the base url and path provided by the developer to make requests