### PR TITLE
Keep and log an array of previous apps

### DIFF
--- a/src/app/AppContainer.ts
+++ b/src/app/AppContainer.ts
@@ -88,6 +88,7 @@ export default class AppContainer extends EventEmitter<AppContainerEvents> {
             name: 'App selected',
             properties: {
                 previousApps: this.previousApps.map(pa => pa.name),
+                previousApp: previousApp ? previousApp.name : null,
                 currentApp: app.name,
             },
         });


### PR DESCRIPTION
## Motivation
We need to be able to track how users navigate between apps. Which groupings of apps are used in which order. The current solution only tracked the previous app, but didn't work correctly as the current app was set to null before the previous app could be updated

## Solution
Keep an array of the previous apps and add the current app to the head of the array when switching to a new app and log the entire array + the first item in the array to app insights