### PR TITLE
Corrected order of execution and added missing type param on interface

### DIFF
--- a/src/http/HttpClient/IHttpClient.ts
+++ b/src/http/HttpClient/IHttpClient.ts
@@ -83,7 +83,7 @@ export default interface IHttpClient {
      * @param form Optional request init object
      * @param onProgress Callback for progress updates
      */
-    postFormAsync<TResponse>(
+    postFormAsync<TResponse, TExpectedErrorResponse>(
         url: string,
         form: FormData,
         onProgress?: (percentage: number, event: ProgressEvent<XMLHttpRequestEventTarget>) => void

--- a/src/http/HttpClient/index.ts
+++ b/src/http/HttpClient/index.ts
@@ -217,12 +217,12 @@ export default class HttpClient implements IHttpClient {
                 reject(new HttpClientRequestFailedError(url, xhr.status, null));
             });
 
+            xhr.open('POST', url, true);
+
             xhr.setRequestHeader('X-Session-Id', this.sessionId);
             xhr.setRequestHeader('Accept', 'application/json');
             xhr.setRequestHeader('x-pp-refresh', 'true');
             xhr.setRequestHeader('Authorization', 'Bearer ' + token);
-
-            xhr.open('POST', url, true);
 
             xhr.send(form);
         });


### PR DESCRIPTION
This should fix the following error:
```
DOMException: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
```