### PR TITLE
Adds option for custom response parser on file upload and handle quotes in filename

### DIFF
--- a/src/http/HttpClient/IHttpClient.ts
+++ b/src/http/HttpClient/IHttpClient.ts
@@ -82,11 +82,13 @@ export default interface IHttpClient {
      * @param url Request url
      * @param form Optional request init object
      * @param onProgress Callback for progress updates
+     * @param responseParser Optional custom response parser
      */
     postFormAsync<TResponse, TExpectedErrorResponse>(
         url: string,
         form: FormData,
-        onProgress?: (percentage: number, event: ProgressEvent<XMLHttpRequestEventTarget>) => void
+        onProgress?: (percentage: number, event: ProgressEvent<XMLHttpRequestEventTarget>) => void,
+        responseParser?: (response: string) => TResponse
     ): Promise<HttpResponse<TResponse>>;
 
     /**

--- a/src/http/HttpClient/index.ts
+++ b/src/http/HttpClient/index.ts
@@ -172,7 +172,8 @@ export default class HttpClient implements IHttpClient {
     async postFormAsync<TResponse, TExpectedErrorResponse>(
         url: string,
         form: FormData,
-        onProgress?: (percentage: number, event: ProgressEvent<XMLHttpRequestEventTarget>) => void
+        onProgress?: (percentage: number, event: ProgressEvent<XMLHttpRequestEventTarget>) => void,
+        responseParser?: (response: string) => TResponse
     ): Promise<HttpResponse<TResponse>> {
         const token = await this.authContainer.acquireTokenAsync(url);
         return new Promise((resolve, reject) => {
@@ -200,7 +201,9 @@ export default class HttpClient implements IHttpClient {
                 }, new Headers());
 
                 const response: HttpResponse<TResponse> = {
-                    data: JSON.parse<TResponse>(xhr.responseText),
+                    data: responseParser
+                        ? responseParser(xhr.responseText)
+                        : JSON.parse<TResponse>(xhr.responseText),
                     status: xhr.status,
                     headers: headerMap,
                     refreshRequest: null,

--- a/src/http/HttpClient/index.ts
+++ b/src/http/HttpClient/index.ts
@@ -450,7 +450,18 @@ export default class HttpClient implements IHttpClient {
 
         if (!fileNamePart) return null;
 
-        return fileNamePart.split('=')[1];
+        const fileName = fileNamePart.split('=')[1];
+
+        // The API returns filename wrapped in double qutoes to preserve spaces.
+        // These should be replaced when parsing the filename to prevent the browser
+        // from prefixing and postfixing the filname with underscores during download.
+
+        // If we do not replace the quotes, the parsed filename would be a double quoted
+        // string (e.g. ""file.pdf""). The browser would likely create the following
+        // filename when the file is downloaded: _file.pdf_. This would result in the
+        // client not recognising the file format and the user will not be able to open
+        // the file.
+        return fileName.replace(/["]/g, '');
     }
 }
 


### PR DESCRIPTION
### Custom response parser
Added option for providing a custom response parser when uploading files. Handy in case the API does not return anything, because then the default `JSON.parse` will throw...

I wantet to solve this using method two function overloads (this would be the cleanest solution for the user from an API point of view), e.g.:

```typescript
postFormAsync<TResponse, TExpectedErrorResponse>(
    url: string,
    form: FormData,
    onProgress?: (percentage: number, event: ProgressEvent<XMLHttpRequestEventTarget>) => void,
    responseParser?: (response: string) => TResponse
): Promise<HttpResponse<TResponse>>;

// Without TResponse type argument
postFormAsync<TExpectedErrorResponse>(
    url: string,
    form: FormData,
    onProgress?: (percentage: number, event: ProgressEvent<XMLHttpRequestEventTarget>) => void,
    responseParser?: (response: string) => TResponse
): Promise<HttpResponse<any>>;
```

But since Typescript does not support function overloading, I went with the existing `responseParser` pattern to make it consistent.

### Handle double quoted file names in `Content-Disposition`
The API returns filename wrapped in double qutoes to preserve spaces.
These should be replaced when parsing the filename to prevent the browser
from prefixing and postfixing the filname with underscores during download.

If we do not replace the quotes, the parsed filename would be a double quoted
string (e.g. ""file.pdf""). The browser would likely create the following
filename when the file is downloaded: _file.pdf_. This would result in the
client not recognising the file format and the user will not be able to open
the file.