### PR TITLE
Function to enqueue async operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export {
     useCurrentContextTypes,
 } from './core/ContextManager';
 
-export { withAbortController, useAbortControllerManager } from './utils/AbortControllerManager';
+export { withAbortController, useAbortControllerManager, enqueueAsyncOperation, AbortableAction, AsyncOperation } from './utils/AbortControllerManager';
 
 export {
     useComponentDisplayType,


### PR DESCRIPTION
## Problem
When performing continuous DOM checks (like width, height etc.) you would like to do so without locking the process (blocking the browser from rendering) and _after_ a repaint. Using setTimeout will add the callback after repaints, but will block  further repaints until all operations are completed. This will "freeze" the browser completely when using recursive setTimeouts. RequestAnimationFrame will place the callback _before_ the repaint but does not block the browser from repainting

## Solution
Nesting requestAnimationFrame and setTimeout will ensure operations does not block the process and is performed after paint.