### PR TITLE
Export all error types that can be thrown from HttpClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,13 @@ export {
 
 export { default as ServiceResolver } from './http/resourceCollections/ServiceResolver';
 
-export { default as HttpClient, IHttpClient } from './http/HttpClient';
+export {
+    default as HttpClient,
+    IHttpClient,
+    HttpClientError,
+    HttpClientParseError,
+    HttpClientRequestFailedError,
+} from './http/HttpClient';
 
 export {
     default as ResourceCollections,
@@ -47,7 +53,13 @@ export {
     useCurrentContextTypes,
 } from './core/ContextManager';
 
-export { withAbortController, useAbortControllerManager, enqueueAsyncOperation, AbortableAction, AsyncOperation } from './utils/AbortControllerManager';
+export {
+    withAbortController,
+    useAbortControllerManager,
+    enqueueAsyncOperation,
+    AbortableAction,
+    AsyncOperation,
+} from './utils/AbortControllerManager';
 
 export {
     useComponentDisplayType,


### PR DESCRIPTION
Export all error types that can be thrown by `HttpClient` so that we can have type safe error handling, e.g.:

```typescript
try {
  this.httpClient.putAsync<.....................
} (error) {
  const httpClientError = error as HttpClientError;
  ...
}
```