### PR TITLE
App selection history is not kept

### DIFF
--- a/src/app/AppContainer.ts
+++ b/src/app/AppContainer.ts
@@ -91,7 +91,7 @@ export default class AppContainer extends EventEmitter<AppContainerEvents> {
 
     async setCurrentAppAsync(appKey: string | null): Promise<void> {
         const previousApp = this.previousApps.state[0];
-        if (this.currentApp && previousApp && previousApp.key !== appKey) {
+        if (this.currentApp && (!previousApp || previousApp.key !== appKey)) {
             this.previousApps.state = [this.currentApp, ...this.previousApps.state];
         }
 


### PR DESCRIPTION
It was checking that there was a previous app and that the key does not match the current app, but when the app history is empty it will never add an app to the history and the entire condition will always be false. Refactoring the condition to check if the previous app is _not_ set **or** the previous app key does not match the current app key