### PR TITLE
Minor bug fixes

### DIFF
--- a/src/app/AppContainer.ts
+++ b/src/app/AppContainer.ts
@@ -103,7 +103,7 @@ export default class AppContainer extends EventEmitter<AppContainerEvents> {
                     name: pa.name,
                 })),
             });
-    
+
             this.featureLogger.setCurrentApp(null);
 
             this._currentApp.state = null;
@@ -229,6 +229,10 @@ const useCurrentApp = () => {
         app => app,
         app.container.currentApp
     );
+
+    // Only to get notified/rerendered when changes are made to the current app
+    const [_] = useEventEmitterValue(app.container, 'update');
+
     return currentApp;
 };
 

--- a/src/core/PeopleContainer.ts
+++ b/src/core/PeopleContainer.ts
@@ -139,6 +139,10 @@ const usePersonDetails = (personId: string) => {
     );
 
     const getPersonAsync = async (personId: string) => {
+        if(!personId) {
+            return;
+        }
+
         try {
             setFetching(true);
 
@@ -189,6 +193,10 @@ const usePersonImageUrl = (personId: string) => {
     const [imageUrl, setImageUrl] = React.useState<string>(getCachedPersonImageUrl(personId));
 
     const getImageAsync = async (personId: string) => {
+        if(!personId) {
+            return;
+        }
+        
         const cachedImageUrl = getCachedPersonImageUrl(personId);
 
         if (cachedImageUrl !== '') {

--- a/src/http/apiClients/PeopleClient.ts
+++ b/src/http/apiClients/PeopleClient.ts
@@ -16,6 +16,7 @@ import { PersonODataExpand } from '../resourceCollections/PeopleResourceCollecti
 import GroupRoleMapping from './models/people/GroupRoleMapping';
 import RoleStatus from './models/people/RoleStatus';
 import ServiceResolver from '../resourceCollections/ServiceResolver';
+import fusionConsole from '../../utils/fusionConsole';
 
 export {
     PersonDetails,
@@ -30,20 +31,31 @@ export {
 };
 
 export default class PeopleClient extends BaseApiClient {
-    constructor(httpClient: IHttpClient, resourceCollection: ResourceCollections, serviceResolver: ServiceResolver) {
+    constructor(
+        protected httpClient: IHttpClient,
+        protected resourceCollection: ResourceCollections,
+        serviceResolver: ServiceResolver
+    ) {
         super(httpClient, resourceCollection, serviceResolver);
+        this.apiSigninAsync();
+    }
 
-        httpClient.getAsync<void, unknown>(
-            resourceCollection.people.apiSignin(),
-            { credentials: 'include' },
-            async () => Promise.resolve()
-        );
+    private apiSigninAsync() {
+        try {
+            this.httpClient.getAsync<void, unknown>(
+                this.resourceCollection.people.apiSignin(),
+                { credentials: 'include' },
+                async () => Promise.resolve()
+            );
+        } catch (e) {
+            fusionConsole.error(e);
+        }
     }
 
     protected getBaseUrl() {
         return this.serviceResolver.getPeopleBaseUrl();
     }
-    
+
     async getPersonDetailsAsync(id: string, oDataExpand?: PersonODataExpand[]) {
         const url = this.resourceCollections.people.getPersonDetails(id, oDataExpand);
         return await this.httpClient.getAsync<PersonDetails, FusionApiHttpErrorResponse>(url, {

--- a/src/utils/AbortControllerManager.ts
+++ b/src/utils/AbortControllerManager.ts
@@ -76,14 +76,16 @@ const enqueueAsyncOperation = <T = void>(operation: AsyncOperation<T>, abortSign
             return reject();
         }
 
-        abortSignal?.addEventListener("abort", () => reject());
-
-        const animationFrame = window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
             if(abortSignal?.aborted) {
                 return reject();
             }
 
-            const timer = setTimeout(async () => {
+            setTimeout(async () => {
+                if(abortSignal?.aborted) {
+                    return reject();
+                }
+
                 try {
                     const result = operation();
                     resolve(result);
@@ -92,11 +94,7 @@ const enqueueAsyncOperation = <T = void>(operation: AsyncOperation<T>, abortSign
                     reject(e);
                 }
             }, 0);
-
-            abortSignal?.addEventListener("abort", () => clearTimeout(timer));
         });
-
-        abortSignal?.addEventListener("abort", () => window.cancelAnimationFrame(animationFrame));
     });
 };
 


### PR DESCRIPTION
- enqueueAsyncOperation spent most of its time regestering events on the abort signal. Refactored it to not perform the operation if the signal is aborted. Otherwise go ahead
- Catch error when performing people api signin
- Trigger rerender of components using the useCurrentApp() hook when changes are made to the app manifests
- Protect agains empty strings/null in person hooks