### PR TITLE
useCurrentContext - Update callback when current context changes

### DIFF
--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -89,14 +89,16 @@ export default class ContextManager extends ReliableDictionary<ContextCache> {
 
         const history = await this.getAsync('history');
         this.featureLogger.log('Context selected', '0.0.1', {
-            selectedContext: context ? {
-                id: context.id,
-                name: context.title,
-            } : null,
+            selectedContext: context
+                ? {
+                      id: context.id,
+                      name: context.title,
+                  }
+                : null,
             previusContexts: (history || []).map(c => ({ id: c.id, name: c.title })),
         });
 
-        if(context) {
+        if (context) {
             this.featureLogger.setCurrentContext(context.id, context.title);
         } else {
             this.featureLogger.setCurrentContext(null, null);
@@ -252,11 +254,14 @@ const useCurrentContext = () => {
     const contextManager = useContextManager();
     const [currentContext, setCurrentContext] = useState(contextManager.getCurrentContext());
 
-    const setContext = useCallback((contextCache: ContextCache) => {
-        if (contextCache.current !== currentContext) {
-            setCurrentContext(contextCache.current);
-        }
-    }, []);
+    const setContext = useCallback(
+        (contextCache: ContextCache) => {
+            if (contextCache.current !== currentContext) {
+                setCurrentContext(contextCache.current);
+            }
+        },
+        [currentContext]
+    );
 
     useEffect(() => {
         contextManager.toObjectAsync().then(setContext);


### PR DESCRIPTION
The relevant change is on line 263.

### Affected component(s)
- Context Selector

### Problem
We are using the new context selector in the Query app, and the problem we are seeing is that clearing the context does clear the context in local storage, but the project name is still visible until page reload. I managed to reproduce the problem in fusion components storybook, and it didn't seem like the local context state in the `useCurrentContext` hook was updated after clearing the context.

### Theory and solution attempt
This problem was kind of hard to debug and test because the involved components are distributed between multiple packages (fusion portal / fusion cli, fusion-components and fusion-api), so I do not know for sure that this will solve the issue.

My theory however is that the `setContext` callback in the `useCurrentContext` hook is not updated when the local `currentContext` is updated.

**Example**: The hook is called and the initial state of `currentContext` is null. When a context is selected, it will pass the following check because `contextCache.current` is different from `null`, and the context will be set:
```typescript
if (contextCache.current !== currentContext) {
    setCurrentContext(contextCache.current);
}
```
This works fine, but if we are clearing the context after it has been selected, the callback still sees `currentContext` as `null`. Therefore, the condition will evaluate to false because `null` is not different from `null`, and the local hook state will not be updated. By adding `currentContext` to the callback's dependency array, the condition will always be evaluated based on the most recent data.