### PR TITLE
Update version ts when bumping

### DIFF
--- a/.github/workflows/buildAndPublish.yml
+++ b/.github/workflows/buildAndPublish.yml
@@ -23,14 +23,6 @@ jobs:
         npm ci
         npm run update-version-definition:no-commit
         npm run tsc
-    - name: Commit changes and push
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      run: |
-        git config --local user.email "fusion@equinor.com"
-        git config --local user.name "GitHub Action by Fusion Team"
-        git commit -m "Update version.ts" -a
-        git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:master
     - name: npm publish
       run: | 
         npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "update-version-definition:no-commit": "echo \"export default '$npm_package_version';\" > src/version.ts ",
         "build": "npm run update-version-definition && npm run tsc",
         "tsc": "tsc -p ./tsconfig.json",
-        "tsc:version": "tsc --version"
+        "tsc:version": "tsc --version",
+        "version": "echo \"export default '$npm_package_version';\" > src/version.ts"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem
The version.ts file is used to tag http request etc. with the current fusion api version and needs to be updated when the package version is changed. Currently this is done in the build and publish action, but after adding more policies to the master branch (build action and review) the build and publish action fails when pushing the version.ts change

## Solution
Perform the change to version.ts when running `npm version patch` by adding an npm script `version` which is run AFTER incrementing version but BEFORE commit