### PR TITLE
Align person model with api contract

### DIFF
--- a/src/http/apiClients/models/people/PersonContract.ts
+++ b/src/http/apiClients/models/people/PersonContract.ts
@@ -5,7 +5,7 @@ type PersonContract = {
     name: string;
     companyId?: string;
     companyName: string;
-    number: string;
+    contractNumber: string;
     project: PersonProject;
 };
 

--- a/src/http/apiClients/models/people/PersonProject.ts
+++ b/src/http/apiClients/models/people/PersonProject.ts
@@ -1,8 +1,8 @@
 type PersonProject = {
     id: string;
     name: string;
-    pimsDomainId: string;
-    wbs: string;
+    domainId: string;
+    type: string;
 };
 
 export default PersonProject;


### PR DESCRIPTION
Version 3 of the people API which is used by `PeopleClient` does not correspond to the models defined in `fusion-api`. This PR aligns the models with the response model defined in the people API.

Technically a breaking change. Should we bump the major version of `fusion-api` or do we have sufficient control over the usages so that we can treat this as a patch or minor version upgrade?

As far as I can see, we only have to update `PersonPositionCard.stories` in `fusion-components`.

Example response from
`GET https://pro-s-people-ci.azurewebsites.net/persons/26c3e768-7bb4-4bbc-b574-ba55edbd9d37?$expand=positions,contracts,roles`
```json
{
  "positions": [],
  "contracts": [
    {
      "id": "b9cf46e1-22d7-4e85-bbdc-478433da985d",
      "name": "Software & engineering",
      "contractNumber": "456034",
      "companyId": "a86e8c38-cf38-4f9f-499d-08d726ea3890",
      "companyName": "Bouvet ASA",
      "project": {
        "id": "569d6ac9-b5f7-4338-a9a5-3dd028288996",
        "name": "Query test project",
        "domainId": "query",
        "type": "PRD"
      },
      "positions": [
        {
          "id": "3f3f696b-48ca-4ab1-be7a-a70b6b9cb1e6",
          "name": "Frontend developer",
          "obs": "",
          "basePosition": {
            "id": "6d3e3fab-336e-4864-b064-4a474d184e83",
            "name": "Engineering Manager",
            "type": "PRD-Contracts",
            "discipline": "Engineering Management"
          }
        }
      ]
    }
  ],
  "roles": [],
  "azureUniqueId": "26c3e768-7bb4-4bbc-b574-ba55edbd9d37",
  "mail": "stian.sandve@bouvet.no",
  "name": "Stian Sandve",
  "jobTitle": null,
  "department": null,
  "mobilePhone": null,
  "officeLocation": null,
  "upn": "stian.sandve_bouvet.no#EXT#@StatoilSRM.onmicrosoft.com",
  "isExpired": false,
  "accountType": "External",
  "company": null
}
```