### PR TITLE
Bugfix/continue showing unhandled notifications

### DIFF
--- a/src/core/NotificationCenter.tsx
+++ b/src/core/NotificationCenter.tsx
@@ -185,6 +185,10 @@ export default class NotificationCenter extends ReliableDictionary<
     }
 
     private async persistAsync(notification: Notification) {
+        if (notification.request.level === 'low') {
+            return;
+        }
+
         const notifications = await this.getAllNotificationsAsync();
 
         const existing = notifications.find(n => n.id === notification.id);

--- a/src/core/NotificationCenter.tsx
+++ b/src/core/NotificationCenter.tsx
@@ -155,7 +155,7 @@ export default class NotificationCenter extends ReliableDictionary<
     private async shouldPresentNotificationAsync(notificationRequest: NotificationRequest) {
         const allNotifications = await this.getAllNotificationsAsync();
 
-        if (allNotifications.find(n => n.id === notificationRequest.id)) {
+        if (allNotifications.find(n => n.responded !== null && n.id === notificationRequest.id)) {
             return false;
         }
 


### PR DESCRIPTION
## Problem
Once a notification is shown, it's persisted in local storage. If the same notification is presented again it's ignored by the notification center. However, if the notification was never handled/dismissed by the user it will still be ignored.

## Solution
Only ignore handled/dismissed notifications in the notification center