### PR TITLE
Feature logger logs context for apps that don't support context

### DIFF
--- a/src/app/AppContainer.ts
+++ b/src/app/AppContainer.ts
@@ -135,7 +135,7 @@ export default class AppContainer extends EventEmitter<AppContainerEvents> {
             },
         });
 
-        if(!app.context) {
+        if (!app.context) {
             // Reset context on feature logger if current app does not support it
             this.featureLogger.setCurrentContext(null, null);
         }

--- a/src/app/AppContainer.ts
+++ b/src/app/AppContainer.ts
@@ -135,6 +135,11 @@ export default class AppContainer extends EventEmitter<AppContainerEvents> {
             },
         });
 
+        if(!app.context) {
+            // Reset context on feature logger if current app does not support it
+            this.featureLogger.setCurrentContext(null, null);
+        }
+
         this.featureLogger.log('App selected', '0.0.1', {
             selectedApp: {
                 key: app.key,

--- a/src/core/FusionContext.ts
+++ b/src/core/FusionContext.ts
@@ -166,7 +166,13 @@ export const createFusionContext = (
     );
     appContainerFactory(appContainer);
 
-    const contextManager = new ContextManager(apiClients, appContainer, featureLogger, history);
+    const contextManager = new ContextManager(
+        apiClients,
+        appContainer,
+        featureLogger,
+        telemetryLogger,
+        history
+    );
     const tasksContainer = new TasksContainer(apiClients, new EventHub());
     const notificationCenter = new NotificationCenter(new EventHub());
     const peopleContainer = new PeopleContainer(apiClients, resourceCollections, new EventHub());


### PR DESCRIPTION
## Problem
The feature logger keeps track of the current context selected so that it can be added as metadata on each feature log from Fusion. The problem is that when selecting a new app, that context is stil set on the feature logger and added to the app selection log. Even if the app does not support context (e.g. tasks.) It also causes apps that don't support the same context type to be logged with incorrect context

## Solution
Clear the current context from the feature logger when switching to an app that does not support the selected context