### PR TITLE
Retry http requests automatically

### DIFF
--- a/src/app/AppContainer.ts
+++ b/src/app/AppContainer.ts
@@ -9,10 +9,16 @@ import FeatureLogger from '../utils/FeatureLogger';
 import DistributedState, { IDistributedState } from '../utils/DistributedState';
 import { IEventHub } from '../utils/EventHub';
 import { ContextManifest } from '../http/apiClients/models/context/ContextManifest';
+import { AppAuth } from '../http/apiClients/models/fusion/apps/AppManifest';
 
 type AppRegistration = {
     AppComponent: React.ComponentType;
+    name?: string;
+    shortName?: string;
+    description?: string;
     context?: ContextManifest;
+    auth?: AppAuth;
+    icon?: string;
 };
 
 type AppContainerEvents = {


### PR DESCRIPTION
- Retries failed requests (e.g. 502 etc.) automatically in a given "timeframe"
- Also adds optional name etc. to app registration to display when the app is running through fusion CLI