### PR TITLE
Avoid parallel app logins

### DIFF
--- a/src/auth/AuthCache.ts
+++ b/src/auth/AuthCache.ts
@@ -8,6 +8,7 @@ enum TokenCacheKey {
     TOKEN = "TOKEN",
     USER = "USER",
     REDIRECT_URL = "REDIRECT_URL",
+    LOGIN_LOCK_STATUS = "LOGIN_LOCK_STATUS",
 };
 
 export default class AuthCache extends ReliableDictionary {
@@ -64,5 +65,22 @@ export default class AuthCache extends ReliableDictionary {
         const redirectUrl = await this.getAsync<string, string>(TokenCacheKey.REDIRECT_URL);
         await this.removeAsync(TokenCacheKey.REDIRECT_URL);
         return redirectUrl;
+    }
+
+    // private static createAppLoginKey(clientId: string) {
+    //     return `${TokenCacheKey.LOGIN_LOCK_STATUS}-${clientId.trim()}`;
+    // }
+
+    async setLoginLock() {
+        await this.setAsync(TokenCacheKey.LOGIN_LOCK_STATUS, "locked");
+    }
+
+    async releaseLoginLock() {
+        await this.setAsync(TokenCacheKey.LOGIN_LOCK_STATUS, "open");
+    }
+
+    async isLoginLocked() {
+        const lockStatus = await this.getAsync<string, string>(TokenCacheKey.LOGIN_LOCK_STATUS);
+        return lockStatus === "locked";
     }
 }

--- a/src/auth/AuthCache.ts
+++ b/src/auth/AuthCache.ts
@@ -4,7 +4,7 @@ import AuthUser, { AuthUserJSON } from './AuthUser';
 import ReliableDictionary, { LocalStorageProvider } from '../utils/ReliableDictionary';
 import EventHub from '../utils/EventHub';
 
-enum TokenCacheKey {
+enum CacheKey {
     TOKEN = "TOKEN",
     USER = "USER",
     REDIRECT_URL = "REDIRECT_URL",
@@ -16,20 +16,20 @@ export default class AuthCache extends ReliableDictionary {
         super(new LocalStorageProvider('FUSION_AUTH_CACHE', new EventHub()));
     }
 
-    private static createAppCacheKey(app: AuthApp, key: TokenCacheKey) {
+    private static createAppCacheKey(app: AuthApp, key: CacheKey) {
         return `FUSION_AUTH_CACHE:${app.clientId}:${key}`;
     }
 
     async storeTokenAsync(app: AuthApp, token: AuthToken) {
         await this.setAsync(
-            AuthCache.createAppCacheKey(app, TokenCacheKey.TOKEN),
+            AuthCache.createAppCacheKey(app, CacheKey.TOKEN),
             token.toString()
         );
     }
 
     async getTokenAsync(app: AuthApp) {
         const originalToken = await this.getAsync<string, string>(
-            AuthCache.createAppCacheKey(app, TokenCacheKey.TOKEN)
+            AuthCache.createAppCacheKey(app, CacheKey.TOKEN)
         );
 
         if (!originalToken) {
@@ -40,15 +40,15 @@ export default class AuthCache extends ReliableDictionary {
     }
 
     async clearTokenAsync(app: AuthApp) {
-        await this.removeAsync(AuthCache.createAppCacheKey(app, TokenCacheKey.TOKEN));
+        await this.removeAsync(AuthCache.createAppCacheKey(app, CacheKey.TOKEN));
     }
 
     async storeUserAsync(user: AuthUser) {
-        await this.setAsync(TokenCacheKey.USER, user.toObject());
+        await this.setAsync(CacheKey.USER, user.toObject());
     }
 
     async getUserAsync() {
-        const cachedUser = await this.getAsync<string, AuthUserJSON>(TokenCacheKey.USER);
+        const cachedUser = await this.getAsync<string, AuthUserJSON>(CacheKey.USER);
 
         if (cachedUser === null) {
             return null;
@@ -58,25 +58,25 @@ export default class AuthCache extends ReliableDictionary {
     }
 
     async storeRedirectUrl(redirectUrl: string) {
-        await this.setAsync(TokenCacheKey.REDIRECT_URL, redirectUrl);
+        await this.setAsync(CacheKey.REDIRECT_URL, redirectUrl);
     }
 
     async getRedirectUrl() {
-        const redirectUrl = await this.getAsync<string, string>(TokenCacheKey.REDIRECT_URL);
-        await this.removeAsync(TokenCacheKey.REDIRECT_URL);
+        const redirectUrl = await this.getAsync<string, string>(CacheKey.REDIRECT_URL);
+        await this.removeAsync(CacheKey.REDIRECT_URL);
         return redirectUrl;
     }
 
     async setLoginLock() {
-        await this.setAsync(TokenCacheKey.LOGIN_LOCK_STATUS, "locked");
+        await this.setAsync(CacheKey.LOGIN_LOCK_STATUS, "locked");
     }
 
     async releaseLoginLock() {
-        await this.setAsync(TokenCacheKey.LOGIN_LOCK_STATUS, "open");
+        await this.setAsync(CacheKey.LOGIN_LOCK_STATUS, "open");
     }
 
     async isLoginLocked() {
-        const lockStatus = await this.getAsync<string, string>(TokenCacheKey.LOGIN_LOCK_STATUS);
+        const lockStatus = await this.getAsync<string, string>(CacheKey.LOGIN_LOCK_STATUS);
         return lockStatus === "locked";
     }
 }

--- a/src/auth/AuthCache.ts
+++ b/src/auth/AuthCache.ts
@@ -67,10 +67,6 @@ export default class AuthCache extends ReliableDictionary {
         return redirectUrl;
     }
 
-    // private static createAppLoginKey(clientId: string) {
-    //     return `${TokenCacheKey.LOGIN_LOCK_STATUS}-${clientId.trim()}`;
-    // }
-
     async setLoginLock() {
         await this.setAsync(TokenCacheKey.LOGIN_LOCK_STATUS, "locked");
     }

--- a/src/auth/AuthCache.ts
+++ b/src/auth/AuthCache.ts
@@ -8,7 +8,7 @@ enum CacheKey {
     TOKEN = "TOKEN",
     USER = "USER",
     REDIRECT_URL = "REDIRECT_URL",
-    LOGIN_LOCK_STATUS = "LOGIN_LOCK_STATUS",
+    APP_LOGIN_LOCK = "APP_LOGIN_LOCK",
 };
 
 export default class AuthCache extends ReliableDictionary {
@@ -67,16 +67,19 @@ export default class AuthCache extends ReliableDictionary {
         return redirectUrl;
     }
 
-    async setLoginLock() {
-        await this.setAsync(CacheKey.LOGIN_LOCK_STATUS, "locked");
+    async setAppLoginLock(clientId: string) {
+        await this.setAsync(CacheKey.APP_LOGIN_LOCK, clientId);
     }
 
-    async releaseLoginLock() {
-        await this.setAsync(CacheKey.LOGIN_LOCK_STATUS, "open");
+    async clearAppLoginLock(clientId: string) {
+        const currentAppIdLock = await this.getAsync<string, string>(CacheKey.APP_LOGIN_LOCK);
+        if (currentAppIdLock === clientId)
+            await this.setAsync(CacheKey.APP_LOGIN_LOCK, "");
     }
 
-    async isLoginLocked() {
-        const lockStatus = await this.getAsync<string, string>(CacheKey.LOGIN_LOCK_STATUS);
-        return lockStatus === "locked";
+    async isAppLoginLocked() {
+        const lockingAppId = await this.getAsync<string, string>(CacheKey.APP_LOGIN_LOCK);
+        const isUnlocked = lockingAppId === null || lockingAppId === "";
+        return !isUnlocked;
     }
 }

--- a/src/auth/AuthCache.ts
+++ b/src/auth/AuthCache.ts
@@ -73,8 +73,9 @@ export default class AuthCache extends ReliableDictionary {
 
     async clearAppLoginLock(clientId: string) {
         const currentAppIdLock = await this.getAsync<string, string>(CacheKey.APP_LOGIN_LOCK);
-        if (currentAppIdLock === clientId)
-            await this.setAsync(CacheKey.APP_LOGIN_LOCK, "");
+        if (currentAppIdLock === clientId) {
+            await this.setAsync(CacheKey.APP_LOGIN_LOCK, "")
+        };
     }
 
     async isAppLoginLocked() {

--- a/src/auth/AuthContainer.ts
+++ b/src/auth/AuthContainer.ts
@@ -168,6 +168,7 @@ export default class AuthContainer implements IAuthContainer {
         const cachedToken = await this.cache.getTokenAsync(newApp);
 
         if (cachedToken !== null) {
+            await this.cache.releaseLoginLock();
             return true;
         }
 
@@ -192,8 +193,6 @@ export default class AuthContainer implements IAuthContainer {
         // Login page cannot be displayed within a frame
         // Get the top level window and redirect there
         getTopLevelWindow(window).location.href = await this.buildLoginUrlAsync(app, nonce);
-
-        await this.cache.releaseLoginLock();
     }
 
     async logoutAsync(clientId?: string) {

--- a/src/auth/AuthContainer.ts
+++ b/src/auth/AuthContainer.ts
@@ -168,7 +168,7 @@ export default class AuthContainer implements IAuthContainer {
         const cachedToken = await this.cache.getTokenAsync(newApp);
 
         if (cachedToken !== null) {
-            await this.cache.releaseLoginLock();
+            await this.cache.clearAppLoginLock(clientId);
             return true;
         }
 
@@ -181,11 +181,11 @@ export default class AuthContainer implements IAuthContainer {
             throw new FusionAuthAppNotFoundError(clientId);
         }
 
-        const isLockedByOtherApp = await this.cache.isLoginLocked();
-        if (isLockedByOtherApp) {
+        const isLocked = await this.cache.isAppLoginLocked();
+        if (isLocked) {
             return;
         }
-        await this.cache.setLoginLock();
+        await this.cache.setAppLoginLock(clientId);
 
         const nonce = AuthNonce.createNew(app);
         this.cache.storeRedirectUrl(getTopLevelWindow(window).location.href);


### PR DESCRIPTION
- AuthCache:
   - Rename enum `TokenCacheKey` => `CacheKey`
   - Add new constant `CacheKey.APP_LOGIN_LOCK `
   - Add new functions for setting and accessing a login-lock
      - `setAppLoginLock`, `clearAppLoginLock`, `isAppLoginLocked`
- AuthContainer
   - `loginAsync`: skip login if some other login process has started. Implemented by using the new login-lock functions of AuthCache
  - `registerAppAsync`: clear the app's login-lock when the app has successfully gotten a token