### PR TITLE
Separate get-functions for Blob and File

### DIFF
--- a/src/http/HttpClient/IHttpClient.ts
+++ b/src/http/HttpClient/IHttpClient.ts
@@ -1,5 +1,6 @@
 import { HttpResponse } from './HttpResponse';
 import RequestBody from '../models/RequestBody';
+import BlobContainer from '../models/BlobContainer';
 
 export type ResponseParser<T> = (response: Response) => Promise<T>;
 
@@ -92,8 +93,14 @@ export default interface IHttpClient {
     ): Promise<HttpResponse<TResponse>>;
 
     /**
-     *  Performs a GET request and converts the response to a File
+     *  Performs a GET request and converts the response to a Blob
      * @param url Request url
      */
-    getBlobAsync<TExpectedErrorResponse>(url: string): Promise<File>;
+    getBlobAsync<TExpectedErrorResponse>(url: string): Promise<BlobContainer>;
+
+    /**
+    *  Performs a GET request and converts the response to a File
+    * @param url Request url
+    */
+    getFileAsync<TExpectedErrorResponse>(url: string): Promise<File>;
 }

--- a/src/http/models/BlobContainer.ts
+++ b/src/http/models/BlobContainer.ts
@@ -1,0 +1,6 @@
+type BlobContainer = {
+    blob: Blob,
+    fileName: string
+};
+
+export default BlobContainer;


### PR DESCRIPTION
- Create new type `BlobContainer`
   - `{ blob, fileName }`
- Return `BlobContainer` in `getBlobAsync`
- Create new function `getFileAsync` for returning File (identical to previous `getBlobAsync` implementation)
- Update interface `IHttpClient`

Fixes #180