### PR TITLE
Auth: Force redirect routing, incl. some login-lock improvements

### DIFF
--- a/src/auth/AuthCache.ts
+++ b/src/auth/AuthCache.ts
@@ -74,7 +74,7 @@ export default class AuthCache extends ReliableDictionary {
     async clearAppLoginLock(clientId: string) {
         const currentAppIdLock = await this.getAsync<string, string>(CacheKey.APP_LOGIN_LOCK);
         if (currentAppIdLock === clientId) {
-            await this.setAsync(CacheKey.APP_LOGIN_LOCK, "")
+            await this.removeAsync(CacheKey.APP_LOGIN_LOCK);
         };
     }
 

--- a/src/auth/AuthContainer.ts
+++ b/src/auth/AuthContainer.ts
@@ -114,7 +114,8 @@ export default class AuthContainer implements IAuthContainer {
                 redirectUrl &&
                 AuthContainer.getResourceOrigin(redirectUrl) === window.location.origin
             ) {
-                window.location.href = redirectUrl;
+                window.history.replaceState(null, "", redirectUrl);
+                window.location.reload(true);
             }
         } catch (e) {
             this.logError(e);


### PR DESCRIPTION
`AuthContainer`:
- `handleWindowCallbackAsync`:
  - Force window reload when setting `redirectUrl` after login
- `registerAppAsync`
  - When setting or clearing lock, use clientId of resolved app instead of param
  - Clear login-lock (if owned by the app) when app exists and has token

`AuthCache`:
- When clearing lock, remove the key entirely instead of setting it to `""`

Closes #198 