### PR TITLE
People Client does a non-exsiting get request to api-signing

### DIFF
--- a/src/http/apiClients/PeopleClient.ts
+++ b/src/http/apiClients/PeopleClient.ts
@@ -43,9 +43,10 @@ export default class PeopleClient extends BaseApiClient {
 
     private apiSigninAsync() {
         try {
-            this.httpClient.getAsync<void, unknown>(
+            this.httpClient.postAsync<any, unknown, unknown>(
                 this.resourceCollection.people.apiSignin(),
                 { credentials: 'include' },
+                null,
                 async () => Promise.resolve()
             );
         } catch (e) {

--- a/src/http/apiClients/PowerBIClient.ts
+++ b/src/http/apiClients/PowerBIClient.ts
@@ -4,6 +4,7 @@ import PbiReport from './models/powerbi/PowerBIReport';
 import ApiError from './models/powerbi/PowerBIError';
 import AuthToken from '../../auth/AuthToken';
 import BaseApiClient from './BaseApiClient';
+import PowerBIDataset from './models/powerbi/PoweBIDataset';
 
 interface IReportItem {
     [groupId: string]: PbiReport[];
@@ -22,7 +23,7 @@ export default class PowerBIClient extends BaseApiClient {
     protected getBaseUrl() {
         return this.serviceResolver.getReportsBaseUrl();
     }
-    
+
     private async getPowerBITokenAsync(): Promise<string> {
         if (this.powerBiToken && AuthToken.parse(this.powerBiToken).isValid())
             return this.powerBiToken;
@@ -31,9 +32,19 @@ export default class PowerBIClient extends BaseApiClient {
             'https://analysis.windows.net/powerbi/api'
         );
 
-        const response = await this.httpClient.getAsync<string, any>(url, null, r => r.text());
+        const response = await this.httpClient.getAsync<string, any>(url, null, (r) => r.text());
         this.powerBiToken = response.data;
         return response.data;
+    }
+
+    public async getDatasetAsync(groupId: string, dataSet: string) {
+        const options = await this.buildRequestOptionsWithToken();
+        const response = await fetch(
+            this.resourceCollections.powerBI.datasets(groupId, dataSet),
+            options
+        );
+
+        return await this.handleResponse(response);
     }
 
     async getGroupsAsync() {

--- a/src/http/apiClients/models/powerbi/PoweBIDataset.ts
+++ b/src/http/apiClients/models/powerbi/PoweBIDataset.ts
@@ -1,0 +1,15 @@
+type PowerBIDataset = {
+    addRowsAPIEnabled: boolean;
+    configuredBy: string;
+    createReportEmbedUrl: string;
+    id: string;
+    isEffectiveIdentityRequired: boolean;
+    isEffectiveIdentityRolesRequired: boolean;
+    isOnPremGatewayRequired: boolean;
+    isRefreshable: boolean;
+    name: string;
+    qnaEmbedUrl: string;
+    targetStorageMode: string;
+};
+
+export default PowerBIDataset;

--- a/src/http/resourceCollections/PowerBIResourceCollection.ts
+++ b/src/http/resourceCollections/PowerBIResourceCollection.ts
@@ -17,4 +17,8 @@ export default class PowerBIResourceCollection extends BaseResourceCollection {
     dashboards(groupId: string) {
         return combineUrls(this.getBaseUrl(), 'groups', groupId, 'dashboards');
     }
+
+    datasets(groupId: string, dataSet: string) {
+        return combineUrls(this.getBaseUrl(), 'groups', groupId, 'datasets', dataSet);
+    }
 }


### PR DESCRIPTION
There is no get request for the api-signin and you get a 405 everytime this code is called.

This should probably be a post, as thats whats used elsewhere.
Seeing as this has been "wrong" for a long time, one might wonder if this code can be removed ?
Think this fix should atleast fix the failed get request you get every time you load fusion.