### PR TITLE
Bugfix - SignalR hub disconnect every hour

### DIFF
--- a/src/hooks/useSignalRHub.ts
+++ b/src/hooks/useSignalRHub.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
 import { useFusionContext } from '../core/FusionContext';
 
@@ -16,7 +16,7 @@ export default (hubName: string) => {
 
     const signalRHubUrl = useMemo(() => fusion.signalRHub(hubName), [hubName, fusion]);
 
-    const createHubConnectionAsync = async () => {
+    const createHubConnectionAsync = useCallback(async () => {
         setHubConnectionError(null);
         const hubConnect = new HubConnectionBuilder()
             .withAutomaticReconnect()
@@ -35,7 +35,7 @@ export default (hubName: string) => {
         } finally {
             setIsEstablishingHubConnection(false);
         }
-    };
+    }, [signalRHubUrl, auth]);
 
     useEffect(() => {
         createHubConnectionAsync();
@@ -43,7 +43,7 @@ export default (hubName: string) => {
         return () => {
             hubConnection?.stop();
         };
-    }, [signalRHubUrl]);
+    }, [signalRHubUrl, createHubConnectionAsync]);
 
     return { hubConnection, hubConnectionError, isEstablishingHubConnection };
 };

--- a/src/hooks/useSignalRHub.ts
+++ b/src/hooks/useSignalRHub.ts
@@ -43,7 +43,7 @@ export default (hubName: string) => {
         return () => {
             hubConnection?.stop();
         };
-    }, [signalRHubUrl, createHubConnectionAsync]);
+    }, [createHubConnectionAsync]);
 
     return { hubConnection, hubConnectionError, isEstablishingHubConnection };
 };

--- a/src/http/resourceCollections/FusionResourceCollection.ts
+++ b/src/http/resourceCollections/FusionResourceCollection.ts
@@ -44,7 +44,7 @@ export default class FusionResourceCollection extends BaseResourceCollection {
     }
 
     signalRHub(hubName: string) {
-        return combineUrls(this.getBaseUrl(), 'signalr', 'hubs', hubName, 'negotiate');
+        return combineUrls(this.getBaseUrl(), 'signalr', 'hubs', hubName);
     }
 
     private getBundlesPath() {


### PR DESCRIPTION
The SinglaR hub disconnected every hour because the token timed out.
Changed the implementation to let the backend deal with negotiation details and token handling