### PR TITLE
DataProxy Handover api for context

### DIFF
--- a/src/http/apiClients/DataProxyClient.ts
+++ b/src/http/apiClients/DataProxyClient.ts
@@ -54,23 +54,21 @@ export default class DataProxyClient extends BaseApiClient {
         );
     }
 
-    async getHandoverAsync(siteCode: string, projectIdentifier: string) {
-        const url = this.resourceCollections.dataProxy.handover(siteCode, projectIdentifier);
-        return await this.httpClient.getAsync<HandoverItem[], FusionApiHttpErrorResponse>(url);
+    async getHandoverAsync(context: string, invalidateCache: boolean) {
+        const url = this.resourceCollections.dataProxy.handover(context);
+        const options = invalidateCache ? { headers: { 'x-pp-cache-policy': 'no-cache' } } : {};
+        return await this.httpClient.getAsync<HandoverItem[], FusionApiHttpErrorResponse>(
+            url,
+            options
+        );
     }
 
     async getHandoverChildrenAsync<TKey extends keyof HandoverActions, T = HandoverActions[TKey]>(
-        siteCode: string,
-        projectIdentifier: string,
+        context: string,
         commpkgId: string,
         action: TKey
     ): Promise<HttpResponse<T[]>> {
-        const url = this.resourceCollections.dataProxy.handoverChildren(
-            siteCode,
-            projectIdentifier,
-            commpkgId,
-            action
-        );
+        const url = this.resourceCollections.dataProxy.handoverChildren(context, commpkgId, action);
         return await this.httpClient.getAsync<T[], FusionApiHttpErrorResponse>(url);
     }
 

--- a/src/http/apiClients/models/dataProxy/handover/HandoverItem.ts
+++ b/src/http/apiClients/models/dataProxy/handover/HandoverItem.ts
@@ -19,6 +19,7 @@ export type HandoverItem = {
     hasOperationAgreement: boolean;
     hasUnsignedActions: boolean;
     hasYellowLineMarkup: boolean;
+    hasBlueLineMarkup: boolean;
     id: string | null;
     isDemolition: boolean;
     isInOperation: boolean;
@@ -39,8 +40,12 @@ export type HandoverItem = {
     priority1: string | null;
     priority2: string | null;
     priority3: string | null;
+    priority1Description: string | null;
+    priority2Description: string | null;
+    priority3Description: string | null;
     progress: string | null;
     projectIdentifier: string | null;
+    projectDescription: string | null;
     remark: string | null;
     responsible: string | null;
     rfccIsAccepted: boolean;

--- a/src/http/apiClients/models/dataProxy/handover/HandoverItem.ts
+++ b/src/http/apiClients/models/dataProxy/handover/HandoverItem.ts
@@ -1,9 +1,11 @@
+import { HandoverStatus } from './HandoverStatus';
+
 export type HandoverItem = {
     actualFinishDate: string | null;
     actualStartDate: string | null;
     area: string | null;
     commpkgNo: string | null;
-    commpkgStatus: string | null;
+    commpkgStatus: HandoverStatus | null;
     createdDate: string | null;
     demolitionActualFinishDate: string | null;
     demolitionActualStartDate: string | null;
@@ -32,7 +34,7 @@ export type HandoverItem = {
     mcPkgsRFCCSigned: number;
     mcPkgsRFOCShipped: number;
     mcPkgsRFOCSigned: number;
-    mcStatus: string | null;
+    mcStatus: HandoverStatus | null;
     phase: string | null;
     plannedFinishDate: string | null;
     plannedStartDate: string | null;

--- a/src/http/apiClients/models/dataProxy/handover/HandoverStatus.ts
+++ b/src/http/apiClients/models/dataProxy/handover/HandoverStatus.ts
@@ -1,0 +1,17 @@
+export type HandoverStatus =
+    | 'PA'
+    | 'PB'
+    | 'RFOC Accepted'
+    | 'RFOC Sent'
+    | 'RFOC Rejected'
+    | 'TAC Accepted'
+    | 'TAC Sent'
+    | 'TAC Rejected'
+    | 'RFCC Rejected'
+    | 'RFCC Accepted'
+    | 'RFCC Sent'
+    | 'DCC'
+    | 'RFRC'
+    | 'OS'
+    | 'No status'
+    | 'OK';

--- a/src/http/hooks/dataProxy/useHandover.ts
+++ b/src/http/hooks/dataProxy/useHandover.ts
@@ -2,37 +2,32 @@ import useApiClient, { ApiClientHookResult } from '../useApiClient';
 import { HandoverItem, HandoverActions } from '../../apiClients/DataProxyClient';
 
 export const useHandover = (
-    siteCode: string,
-    projectIdentifier: string
+    context: string,
+    invalidateCache: boolean
 ): ApiClientHookResult<HandoverItem[]> => {
     return useApiClient<HandoverItem[]>(
         async (apiClients) => {
-            const response = await apiClients.dataProxy.getHandoverAsync(
-                siteCode,
-                projectIdentifier
-            );
+            const response = await apiClients.dataProxy.getHandoverAsync(context, invalidateCache);
             return response.data;
         },
-        [siteCode, projectIdentifier]
+        [context, invalidateCache]
     );
 };
 
-export function useHanoverChild<TKey extends keyof HandoverActions, T = HandoverActions[TKey]>(
-    siteCode: string,
-    projectIdentifier: string,
+export function useHandoverChild<TKey extends keyof HandoverActions, T = HandoverActions[TKey]>(
+    context: string,
     commpkgId: string,
     action: TKey
 ): ApiClientHookResult<T[]> {
     return useApiClient<T[]>(
         async (apiClients) => {
             const response = await apiClients.dataProxy.getHandoverChildrenAsync<TKey, T>(
-                siteCode,
-                projectIdentifier,
+                context,
                 commpkgId,
                 action
             );
             return response.data;
         },
-        [siteCode, projectIdentifier]
+        [context, commpkgId]
     );
 }

--- a/src/http/resourceCollections/DataProxyResourceCollection.ts
+++ b/src/http/resourceCollections/DataProxyResourceCollection.ts
@@ -44,21 +44,12 @@ export default class DataProxyResourceCollection extends BaseResourceCollection 
         return combineUrls(this.getBaseUrl(), 'api-signin');
     }
 
-    handover(siteCode: string, projectIdentifier: string): string {
-        return this.getSiteAndProjectUrl(siteCode, projectIdentifier, 'handover');
+    handover(context: string): string {
+        return combineUrls(this.getBaseUrl(), 'api', 'contexts', context, 'handover');
     }
 
-    handoverChildren(
-        siteCode: string,
-        projectIdentifier: string,
-        commpkgId: string,
-        action: keyof HandoverActions
-    ): string {
-        return this.getSiteAndProjectUrl(
-            siteCode,
-            projectIdentifier,
-            `handover/${commpkgId}/${action}/`
-        );
+    handoverChildren(context: string, commpkgId: string, action: keyof HandoverActions): string {
+        return combineUrls(this.handover(context), commpkgId, action);
     }
 
     accumulatedItem(


### PR DESCRIPTION
DataProxy getHandover and getHandoverChildren updated to use new context endpoints.

HandoverItem update with a few new and missing fields.
DataProxyResourceCollection update with new urls for handover and handoverChildren.
useHandover update to reflect above changes.

This is a breaking change, but I can not find any implementation of these endpoints.
I believe these were just created for future use. 
The ony place I can find the handover beeing used is in the PDP apps (handover and operation garden). 
These gardens uses legacy api that still resides in the project-portal repo.