### PR TITLE
fix: Report Client - checkContextAccess resolve reponse

### DIFF
--- a/src/http/apiClients/ReportClient.ts
+++ b/src/http/apiClients/ReportClient.ts
@@ -150,6 +150,8 @@ export default class ReportClient extends BaseApiClient {
             contextType
         );
 
-        return await this.httpClient.optionsAsync<void, FusionApiHttpErrorResponse>(url);
+        return await this.httpClient.optionsAsync<void, FusionApiHttpErrorResponse>(url, null, () =>
+            Promise.resolve()
+        );
     }
 }


### PR DESCRIPTION
added a custom response parsers. As the response is void, the parser fail.