### PR TITLE
New endpoint in handover to be used for operation garden.

### DIFF
--- a/src/http/apiClients/DataProxyClient.ts
+++ b/src/http/apiClients/DataProxyClient.ts
@@ -20,6 +20,7 @@ import {
     McPunchItem,
     McWorkOrder,
     McNcr,
+    OperationItem,
 } from './models/dataProxy';
 import {
     HandoverActions,
@@ -55,6 +56,15 @@ export default class DataProxyClient extends BaseApiClient {
             { credentials: 'include' },
             undefined,
             voidResponseParser
+        );
+    }
+
+    async getOperationAsync(context: string, invalidateCache: boolean) {
+        const url = this.resourceCollections.dataProxy.operation(context);
+        const options = invalidateCache ? { headers: { 'x-pp-cache-policy': 'no-cache' } } : {};
+        return await this.httpClient.getAsync<OperationItem[], FusionApiHttpErrorResponse>(
+            url,
+            options
         );
     }
 

--- a/src/http/apiClients/models/dataProxy/handover/HandoverItem.ts
+++ b/src/http/apiClients/models/dataProxy/handover/HandoverItem.ts
@@ -1,4 +1,3 @@
-import { HandoverLineStatus } from './HandoverLineStatus';
 import { HandoverStatus } from './HandoverStatus';
 
 export type HandoverItem = {
@@ -23,8 +22,6 @@ export type HandoverItem = {
     hasUnsignedActions: boolean;
     hasYellowLineMarkup: boolean;
     hasBlueLineMarkup: boolean;
-    yellowLineStatus: HandoverLineStatus;
-    blueLineStatus: HandoverLineStatus;
     id: string;
     isDemolition: boolean;
     isInOperation: boolean;

--- a/src/http/apiClients/models/dataProxy/handover/HandoverLineStatus.ts
+++ b/src/http/apiClients/models/dataProxy/handover/HandoverLineStatus.ts
@@ -1,1 +1,0 @@
-export type HandoverLineStatus = 'started' | 'finished' | 'na' | null;

--- a/src/http/apiClients/models/dataProxy/handover/OperationItem.ts
+++ b/src/http/apiClients/models/dataProxy/handover/OperationItem.ts
@@ -1,0 +1,7 @@
+import { HandoverItem } from './HandoverItem';
+import { OperationLineStatus } from './OperationLineStatus';
+
+export type OperationItem = HandoverItem & {
+    yellowLineStatus: OperationLineStatus;
+    blueLineStatus: OperationLineStatus;
+};

--- a/src/http/apiClients/models/dataProxy/handover/OperationLineStatus.ts
+++ b/src/http/apiClients/models/dataProxy/handover/OperationLineStatus.ts
@@ -1,0 +1,1 @@
+export type OperationLineStatus = 'started' | 'finished' | 'na' | null;

--- a/src/http/apiClients/models/dataProxy/index.ts
+++ b/src/http/apiClients/models/dataProxy/index.ts
@@ -1,4 +1,5 @@
 export { HandoverItem } from './handover/HandoverItem';
+export { OperationItem } from './handover/OperationItem';
 export { HandoverMcpkg } from './handover/HandoverMcpkg';
 export { HandoverWorkOrder } from './handover/HandoverWorkOrder';
 export { HandoverUnsignedTask } from './handover/HandoverUnsignedTask';

--- a/src/http/resourceCollections/DataProxyResourceCollection.ts
+++ b/src/http/resourceCollections/DataProxyResourceCollection.ts
@@ -44,6 +44,10 @@ export default class DataProxyResourceCollection extends BaseResourceCollection 
         return combineUrls(this.getBaseUrl(), 'api-signin');
     }
 
+    operation(context: string): string {
+        return combineUrls(this.getBaseUrl(), 'api', 'contexts', context, 'operation');
+    }
+
     handover(context: string): string {
         return combineUrls(this.getBaseUrl(), 'api', 'contexts', context, 'handover');
     }


### PR DESCRIPTION
It is mostly the same as the old handoverItem endpoint, but has some extra fields.
LineStatus fields removed again from the HandoverItem model and moved into new OperationItem.
OperationItem model is handoverItem pluss these two fields.
There are other LineStatus fields that could be added here later. But for now they will not be exposed by the backend, as they wont be used by garden currently.