### PR TITLE
Contextmanager filter contexthistory and replace history

### DIFF
--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import ApiClients from '../http/apiClients';
 import ContextClient from '../http/apiClients/ContextClient';
 import { useFusionContext } from './FusionContext';
-import { Context, ContextTypes, ContextManifest } from '../http/apiClients/models/context';
+import { Context, ContextTypes } from '../http/apiClients/models/context';
 import ReliableDictionary, { LocalStorageProvider } from '../utils/ReliableDictionary';
 import useDebouncedAbortable from '../hooks/useDebouncedAbortable';
 import useApiClients from '../http/hooks/useApiClients';
@@ -78,7 +78,7 @@ export default class ContextManager extends ReliableDictionary<ContextCache> {
 
         const newUrl = await this.buildUrlWithContext();
         if (newUrl && this.history.location.pathname.indexOf(newUrl) !== 0)
-            this.history.push(newUrl);
+            this.history.replace(newUrl);
     };
 
     private async resolveContextFromUrlOrLocalStorageAsync(app: AppManifest | null) {
@@ -152,7 +152,7 @@ export default class ContextManager extends ReliableDictionary<ContextCache> {
                 hasAppPath ? appPath : '',
                 buildUrl(context, scopedPath + this.history.location.search)
             );
-            if (this.history.location.pathname.indexOf(newUrl) !== 0) this.history.push(newUrl);
+            if (this.history.location.pathname.indexOf(newUrl) !== 0) this.history.replace(newUrl);
         }
 
         await this.setAsync('current', context);
@@ -247,7 +247,10 @@ export default class ContextManager extends ReliableDictionary<ContextCache> {
 
     getHistory(): Context[] {
         const value = this.toObject();
-        return value && value.history ? value.history : [];
+        const currentContextTypes = useCurrentContextTypes();
+        return value && value.history
+            ? value.history.filter((context) => currentContextTypes.includes(context.type.id))
+            : [];
     }
 
     async getCurrentContextAsync() {

--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -245,6 +245,9 @@ export default class ContextManager extends ReliableDictionary<ContextCache> {
         return value ? value.current : null;
     }
 
+    getValidContexts = (contexts: Context[]) =>
+        contexts.filter((context) => useCurrentContextTypes().includes(context.type.id));
+
     getHistory(): Context[] {
         const value = this.toObject();
         return value?.history || [];
@@ -319,18 +322,15 @@ const useCurrentContextTypes = () => {
     return app && app.context ? app.context.types : [];
 };
 
-const getValidContexts = (contexts: Context[]) =>
-    contexts.filter((context) => useCurrentContextTypes().includes(context.type.id));
-
 const useContextHistory = () => {
     const contextManager = useContextManager();
     const [history, setHistory] = useState<Context[]>(
-        getValidContexts(contextManager.getHistory())
+        contextManager.getValidContexts(contextManager.getHistory())
     );
 
     const setHistoryFromCache = useCallback((contextCache: ContextCache) => {
         if (contextCache.history !== history) {
-            setHistory(getValidContexts(contextCache.history || []));
+            setHistory(contextManager.getValidContexts(contextCache.history || []));
         }
     }, []);
 

--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -247,10 +247,7 @@ export default class ContextManager extends ReliableDictionary<ContextCache> {
 
     getHistory(): Context[] {
         const value = this.toObject();
-        const currentContextTypes = useCurrentContextTypes();
-        return value && value.history
-            ? value.history.filter((context) => currentContextTypes.includes(context.type.id))
-            : [];
+        return value?.history || [];
     }
 
     async getCurrentContextAsync() {
@@ -322,13 +319,18 @@ const useCurrentContextTypes = () => {
     return app && app.context ? app.context.types : [];
 };
 
+const getValidContexts = (contexts: Context[]) =>
+    contexts.filter((context) => useCurrentContextTypes().includes(context.type.id));
+
 const useContextHistory = () => {
     const contextManager = useContextManager();
-    const [history, setHistory] = useState<Context[]>(contextManager.getHistory());
+    const [history, setHistory] = useState<Context[]>(
+        getValidContexts(contextManager.getHistory())
+    );
 
     const setHistoryFromCache = useCallback((contextCache: ContextCache) => {
         if (contextCache.history !== history) {
-            setHistory(contextCache.history || []);
+            setHistory(getValidContexts(contextCache.history || []));
         }
     }, []);
 


### PR DESCRIPTION
Filter context history. 
The context history will now be get filtered based on the contextTypes that are in use by the app. 
Previsouly it would just show the "raw list", which could include contexts that was not usable in current app. 

currenctContext routing has been changed to use replace instead of push. 
Pushing caused issued where user expected back button to got back to previous page and not to the previous context or just in a circle with the current context. Making it look like the back button didnt no anything
