### PR TITLE
fix: Context Manager - useContextHistory hook rule violation

### DIFF
--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -245,9 +245,6 @@ export default class ContextManager extends ReliableDictionary<ContextCache> {
         return value ? value.current : null;
     }
 
-    getValidContexts = (contexts: Context[]) =>
-        contexts.filter((context) => useCurrentContextTypes().includes(context.type.id));
-
     getHistory(): Context[] {
         const value = this.toObject();
         return value?.history || [];
@@ -322,17 +319,26 @@ const useCurrentContextTypes = () => {
     return app && app.context ? app.context.types : [];
 };
 
+const filterContextByContextType = (validContextTypes: ContextTypes[], contexts: Context[]) =>
+    contexts.filter((context) => validContextTypes.includes(context.type.id));
+
 const useContextHistory = () => {
     const contextManager = useContextManager();
+    const validContextTypes = useCurrentContextTypes();
     const [history, setHistory] = useState<Context[]>(
-        contextManager.getValidContexts(contextManager.getHistory())
+        filterContextByContextType(validContextTypes, contextManager.getHistory())
     );
 
-    const setHistoryFromCache = useCallback((contextCache: ContextCache) => {
-        if (contextCache.history !== history) {
-            setHistory(contextManager.getValidContexts(contextCache.history || []));
-        }
-    }, []);
+    const setHistoryFromCache = useCallback(
+        (contextCache: ContextCache) => {
+            if (contextCache.history !== history) {
+                setHistory(
+                    filterContextByContextType(validContextTypes, contextCache.history || [])
+                );
+            }
+        },
+        [validContextTypes]
+    );
 
     useEffect(() => {
         contextManager.toObjectAsync().then(setHistoryFromCache);


### PR DESCRIPTION
Previous solution for filtering valid context types was in violation  with hook rules and created errors in the console when implemented.

Have reimplemented the solution in a slighly different way that should follow the rules properly.