### PR TITLE
add an optional bool to Notification Request Type

### DIFF
--- a/src/core/NotificationCenter.tsx
+++ b/src/core/NotificationCenter.tsx
@@ -30,6 +30,7 @@ export type NotificationRequest = {
     body?: string;
     cancelLabel?: string;
     confirmLabel?: string;
+    hideCancelAction?: boolean;
 
     /**
      * How long should the notification be visible to the user?


### PR DESCRIPTION
In fusion-components, I want to have the opportunity to hide one of the action buttons (Cancel, Confirm) from the modal. Introducing an optional bool that I can set to true if I want to hide the cancel button.

```typescript
  const createNotification = useNotificationCenter();

  createNotification({
                  level: 'high',
                  title: 'Copied to clipboard',
                  confirmLabel: 'Close',
                  hideCancel: true,
                  body: "",
              });
```