### PR TITLE
feat: abortable request hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ start();
 
 ## Hooks
 
-// TODO: @tobiasny write something
-
 ### useAbortableRequest
+This hook will make an HTTP callback abortable, i.e allows for cancellation of a pending HTTP request. The HTTP callback in the example below is defined as `executeRequest`, which will make an HTTP request towards some API client. The callback will be made abortable when the callback is passed onto the `useAbortableRequest` hook, with the custom abort signal handler `onAbort`. E.g if the abortable callback `onInput` initiates a request, but the `MyComponents` component is unmounted, the initiated HTTP request will be cancelled.
+
 ```tsx
 export const MyComponents = () => {
     const {someClient} = useApiClients();

--- a/src/hooks/useAbortableRequest.ts
+++ b/src/hooks/useAbortableRequest.ts
@@ -3,6 +3,10 @@ import { useCallback, useEffect, useRef } from 'react';
 
 /**
  * Hook for making HTTP requests abortable
+ * @typeParam T Specifies the types of input parameters of the HTTP callback function `cb`
+ * @param cb Callback function to be made abortable. Must execute an HTTP request
+ * @param onAbort Custom handler for abort event
+ * @returns HTTP callback function wrapped as an abortable callback
  */
 
 export const useAbortableRequest = <T extends Array<unknown>>(
@@ -14,7 +18,7 @@ export const useAbortableRequest = <T extends Array<unknown>>(
     const abortableRequest = useCallback(
         (...argss: T) => {
             ref.current && ref.current();
-            ref.current = abortable(async (signal) => {
+            ref.current = abortable(async (signal: AbortSignal) => {
                 onAbort && (signal.onabort = onAbort);
                 if (signal.aborted) return;
                 return cb(...argss);

--- a/src/hooks/useAbortableRequest.ts
+++ b/src/hooks/useAbortableRequest.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef } from 'react';
  * Hook for making HTTP requests abortable
  */
 
-export default <T extends Array<unknown>>(
+export const useAbortableRequest = <T extends Array<unknown>>(
     cb: (...args: T) => void,
     onAbort?: ((this: AbortSignal, ev: Event) => any) | null
 ) => {
@@ -27,3 +27,5 @@ export default <T extends Array<unknown>>(
 
     return abortableRequest;
 };
+
+export default useAbortableRequest;

--- a/src/hooks/useAbortableRequest.ts
+++ b/src/hooks/useAbortableRequest.ts
@@ -1,0 +1,29 @@
+import { withAbortController } from '@equinor/fusion';
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Hook for making HTTP requests abortable
+ */
+
+export default <T extends Array<unknown>>(
+    cb: (...args: T) => void,
+    onAbort?: ((this: AbortSignal, ev: Event) => any) | null
+) => {
+    const abortable = withAbortController();
+    const ref = useRef<VoidFunction>();
+    const abortableRequest = useCallback(
+        (...argss: T) => {
+            ref.current && ref.current();
+            ref.current = abortable(async (signal) => {
+                onAbort && (signal.onabort = onAbort);
+                if (signal.aborted) return;
+                return cb(...argss);
+            });
+        },
+        [cb, ref]
+    );
+
+    useEffect(() => ref.current, [ref.current]);
+
+    return abortableRequest;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import useAbortableRequest from './hooks/useAbortableRequest';
+
 export {
     IAuthContainer,
     FusionAuthLoginError,
@@ -228,7 +230,7 @@ export { default as fusionConsole } from './utils/fusionConsole';
 
 export { default as useDebouncedAbortable } from './hooks/useDebouncedAbortable';
 export { default as useDebounce } from './hooks/useDebounce';
-export { default as useAbortableRequest } from './hooks/useAbortableRequest';
+export { useAbortableRequest } from './hooks/useAbortableRequest';
 export { default as useEffectAsync } from './hooks/useEffectAsync';
 export { default as useAsyncData } from './hooks/useAsyncData';
 export { default as useFusionEnvironment } from './hooks/useFusionEnvironment';

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,7 @@ export { default as fusionConsole } from './utils/fusionConsole';
 
 export { default as useDebouncedAbortable } from './hooks/useDebouncedAbortable';
 export { default as useDebounce } from './hooks/useDebounce';
+export { default as useAbortableRequest } from './hooks/useAbortableRequest';
 export { default as useEffectAsync } from './hooks/useEffectAsync';
 export { default as useAsyncData } from './hooks/useAsyncData';
 export { default as useFusionEnvironment } from './hooks/useFusionEnvironment';


### PR DESCRIPTION
Hook for making HTTP requests abortable.

Utilizes the abortController provided by fusion-api.