### PR TITLE
Report Client - new RLS Validation endpoint

### DIFF
--- a/src/http/apiClients/ReportClient.ts
+++ b/src/http/apiClients/ReportClient.ts
@@ -7,6 +7,8 @@ import ConfigValidation from './models/report/ConfigValidation';
 import BaseApiClient from './BaseApiClient';
 import UpdateMarkdown from './models/report/UpdateMarkdown';
 import { ContextTypes } from './models/context';
+import { RlsConfiguration } from './models/report';
+import RlsValidationError from './models/report/RlsValidationError';
 
 export default class ReportClient extends BaseApiClient {
     protected getBaseUrl() {
@@ -153,5 +155,14 @@ export default class ReportClient extends BaseApiClient {
         return await this.httpClient.optionsAsync<void, FusionApiHttpErrorResponse>(url, null, () =>
             Promise.resolve()
         );
+    }
+
+    async validateRlsConfiguration(rls: Partial<RlsConfiguration>) {
+        const url = this.resourceCollections.report.validateRlsConfiguration();
+        return await this.httpClient.postAsync<
+            Partial<RlsConfiguration>,
+            Partial<RlsConfiguration>,
+            RlsValidationError | ConfigValidation
+        >(url, rls);
     }
 }

--- a/src/http/apiClients/models/report/RlsConfiguration.ts
+++ b/src/http/apiClients/models/report/RlsConfiguration.ts
@@ -1,90 +1,109 @@
-type BasePositionCondition = {
-    id: string;
-    name: string | null;
-};
+export type RlsMappingType =
+    | 'Unknown'
+    | 'AdGroup'
+    | 'ProjectMembership'
+    | 'AdvancedProjectMembership'
+    | 'ContractMembership'
+    | 'Positions';
 
-type UserTypes = 'Unknown' | 'PermanentEmployee' | 'ExtHire' | 'Consultant' | 'External';
+export type RlsNotFoundMode = 'UserEmail' | 'Null';
 
-type ConditionsMatch = 'Unknown' | 'All' | 'Any';
+export type RlsDelimiter = ';' | '|';
 
-type RoleMemberShipType = 'Unknown' | 'Department' | 'AdGroup' | 'DomainMembership' | 'Account';
+//Unkown is a "deliberate" spelling error. It is spelled like this in the rls-configuration schema.
+export type RlsMatch = 'Unkown' | 'All' | 'Any';
 
-type AccessITRole = {
+export type RlsUserTypes = 'Unknown' | 'PermanentEmployee' | 'ExtHire' | 'Consultant' | 'External';
+
+export type RlsMemberShipRequirementType =
+    | 'Unknown'
+    | 'Department'
+    | 'AdGroup'
+    | 'DomainMembership'
+    | 'Account';
+
+export type AccessITRole = {
     id: string;
     name: string | null;
     url: string | null;
 };
 
-type WorkspaceRole = {
-    requireMembership: boolean;
-    level: string | null;
-};
-
-type Conditions = {
-    role: string | null;
-    obs: string | null;
-    pmt: boolean | null;
-    basePositions: BasePositionCondition[] | null;
-    disciplines: string[] | null;
-    userTypes: UserTypes[] | null;
-};
-
-type ProjectMembershipConfig = {
-    match: ConditionsMatch;
-    conditions: Conditions[];
-};
-
-type RlsAdGroupMapping = {
+export type RlsAdGroupMapping = {
     groupId: string;
     groupName: string | null;
     identityName: string | null;
 };
 
-type RlsIdentityConfiguration = {
-    mappingType: string;
-    notFoundMode: string | null;
-    delimiter: string | null;
-    nameSelector: string | null;
-    adGroupMapping?: RlsAdGroupMapping | null;
-    projectMembershipConfig?: ProjectMembershipConfig | null;
+export type WorkspaceRole = {
+    requireMembership: boolean;
+    level: string | null;
 };
 
-type RlsGlobalAccessRequirement = {
+export type RlsGlobalAccessRequirement = {
     accessIT: AccessITRole | null;
     workspace: WorkspaceRole | null;
 };
 
-type RlsAdGroup = {
+export type RlsIdentityConfiguration = {
+    mappingType: RlsMappingType;
+    notFoundMode: RlsNotFoundMode;
+    delimiter: RlsDelimiter | null;
+    nameSelector: string | null;
+    adGroupMapping?: RlsAdGroupMapping[] | null;
+    projectMembershipConfig?: RlsIdentityProjectMembershipConfig;
+};
+
+export type RlsIdentityProjectMembershipConfig = {
+    match: RlsMatch;
+    conditions: RlsCondition[] | null;
+};
+
+export type RlsCondition = {
+    displayName: string;
+    role?: string | null;
+    obs?: string | null;
+    pmt?: boolean | null;
+    basePositions?: BasePositionCondition[] | null;
+    disciplines?: string[] | null;
+    userTypes?: RlsUserTypes[] | null;
+};
+
+export type BasePositionCondition = {
     id: string;
     name: string | null;
 };
 
-type RlsRoleDomainMembershipConfig = {
-    requiredPositionObs: string[] | null;
-};
-
-type RlsRoleMembershipRequirement = {
-    type: RoleMemberShipType;
-    identifiers: string[] | null;
-    userTypes: UserTypes[] | null;
-    allowExternals: boolean;
-    adGroups?: RlsAdGroup[] | null;
-    domaingConfig?: RlsRoleDomainMembershipConfig | null;
-};
-
-type RlsRoles = {
+export type RlsRoleConfiguration = {
     name: string | null;
-    descriptions: string | null;
+    description: string | null;
     pbiName: string | null;
     isAdminRole: boolean;
-    membership: RlsRoleMembershipRequirement[];
+    membership: RlsRoleMembershipRequirement[] | null;
+};
+
+export type RlsRoleMembershipRequirement = {
+    type: RlsMemberShipRequirementType;
+    identifiers: string[] | null;
+    userTypes: RlsUserTypes[] | null;
+    allowExternals: boolean;
+    adGroups?: RlsAdGroup[] | null;
+    domainConfig?: RlsRoleDomainMembershipConfig;
+};
+
+export type RlsAdGroup = {
+    id: string;
+    name: string | null;
+};
+
+export type RlsRoleDomainMembershipConfig = {
+    requiredPositionObs: string[] | null;
 };
 
 type RlsConfiguration = {
     version: number;
-    globalAccessRequirement: RlsGlobalAccessRequirement;
-    identity: RlsIdentityConfiguration;
-    roles: RlsRoles[];
+    globalAccessRequirement: RlsGlobalAccessRequirement | null;
+    identity: RlsIdentityConfiguration | null;
+    roles: RlsRoleConfiguration[] | null;
 };
 
 export default RlsConfiguration;

--- a/src/http/apiClients/models/report/RlsValidationError.ts
+++ b/src/http/apiClients/models/report/RlsValidationError.ts
@@ -1,0 +1,8 @@
+type RlsValidationError = {
+    error: {
+        message: string;
+        validationError: string;
+    };
+};
+
+export default RlsValidationError;

--- a/src/http/resourceCollections/ReportResourceCollection.ts
+++ b/src/http/resourceCollections/ReportResourceCollection.ts
@@ -75,4 +75,8 @@ export default class ReportResourceCollection extends BaseResourceCollection {
             'checkaccess'
         );
     }
+
+    validateRlsConfiguration() {
+        return combineUrls(this.getBaseUrl(), 'admin', 'test-rls-config');
+    }
 }


### PR DESCRIPTION
new Report client endpoint, validateRlsConfiguration. Used to validate rls configuration input before saving report.
Added new RlsValidationError model that can be returned from the validateRlsConfiguration endpoint if the configuration is not valid.
Updated RlsConfiguration model to be inline with the updated version that is being used in the indevelopment Report Admin.
The changes to the model might look like alot, but it is fairly minor.
Generally the model has been update more strictly in line with the predefined rls-configuration.json schema defined by the backend.
 Both in names used and types